### PR TITLE
Document real control character removal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All the fixes are on by default, but you can pass options to turn them off.
   plain-ASCII straight quotes.
 - If `fix_line_breaks` is true, convert all line breaks to Unix style
   (CRLF and CR line breaks become LF line breaks).
-- If `fix_control_characters` is true, remove all C0 control characters
+- If `remove_control_chars` is true, remove all C0 control characters
   except the common useful ones: TAB, CR, LF, and FF. (CR characters
   may have already been removed by the `fix_line_breaks` step.)
 - If `remove_bom` is True, remove the Byte-Order Mark if it exists.


### PR DESCRIPTION
Noticed this was wrong in the read me, the code seems to want `remove_control_chars` now :+1: 
