### PR TITLE
Update setup.py for pypi specific metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,7 @@ setup(
     },
     project_urls={
         'Documentation': 'http://ftfy.readthedocs.io',
+        "Source Code": "https://github.com/rspeer/python-ftfy",
+        "Issue Tracker": "https://github.com/rspeer/python-ftfy/issues",
     }
 )


### PR DESCRIPTION
Added source-code and issue-tracker URLs. This will make the PyPI page for ftfy share link back to its GitHub repo.

This closes: #198 