### PR TITLE
fix pyproject.toml not to install stray files into site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,11 @@ version = "6.2.0"
 description = "Fixes mojibake and other problems with Unicode, after the fact"
 authors = ["Robyn Speer <rspeer@arborelia.net>"]
 license = "Apache-2.0"
-include = ["README.md", "CHANGELOG.md", "tests"]
+include = [
+    {path = "README.md", format = "sdist"},
+    {path = "CHANGELOG.md", format = "sdist"},
+    {path = "tests", format = "sdist"},
+]
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Fix the `include` directives in `pyproject.toml` to include the relevant files in `sdist` archives only and not in wheels, where they end up being installed straight into site-packages, e.g. as:

    /usr/lib/python3.12/site-packages/CHANGELOG.md
    /usr/lib/python3.12/site-packages/README.md