### PR TITLE
Test fixes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,32 +25,32 @@ def get_command_output(args, stdin=None):
 
 
 def test_basic():
-    output = get_command_output(['poetry', 'run', 'ftfy', TEST_FILENAME])
+    output = get_command_output(['ftfy', TEST_FILENAME])
     assert output == CORRECT_OUTPUT
 
 
 def test_guess_bytes():
-    output = get_command_output(['poetry', 'run', 'ftfy', '-g', TEST_FILENAME])
+    output = get_command_output(['ftfy', '-g', TEST_FILENAME])
     assert output == CORRECT_OUTPUT
 
 
 def test_alternate_encoding():
     # The file isn't really in Windows-1252. But that's a problem ftfy
     # can fix, if it's allowed to be sloppy when reading the file.
-    output = get_command_output(['poetry', 'run', 'ftfy', '-e', 'sloppy-windows-1252', TEST_FILENAME])
+    output = get_command_output(['ftfy', '-e', 'sloppy-windows-1252', TEST_FILENAME])
     assert output == CORRECT_OUTPUT
 
 
 def test_wrong_encoding():
     # It's more of a problem when the file doesn't actually decode.
     with pytest.raises(subprocess.CalledProcessError) as exception:
-        get_command_output(['poetry', 'run', 'ftfy', '-e', 'windows-1252', TEST_FILENAME])
+        get_command_output(['ftfy', '-e', 'windows-1252', TEST_FILENAME])
     assert exception.value.output.decode('utf-8') == FAILED_OUTPUT
 
 
 def test_same_file():
     with pytest.raises(subprocess.CalledProcessError) as exception:
-        get_command_output(['poetry', 'run', 'ftfy', TEST_FILENAME, '-o', TEST_FILENAME])
+        get_command_output(['ftfy', TEST_FILENAME, '-o', TEST_FILENAME])
     error = exception.value.output.decode('utf-8')
     assert error.startswith("ftfy error:")
     assert "Can't read and write the same file" in error
@@ -58,6 +58,6 @@ def test_same_file():
 
 def test_stdin():
     with open(TEST_FILENAME, 'rb') as infile:
-        output = get_command_output(['poetry', 'run', 'ftfy'], stdin=infile)
+        output = get_command_output(['ftfy'], stdin=infile)
         assert output == CORRECT_OUTPUT
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,7 @@
 envlist = py37, py38, py39, py310, py311
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    wcwidth
 commands = pytest


### PR DESCRIPTION
1. Fix redundant `poetry run` use from tests, that causes double indirection and unnecessary (undeclared) dependency on full `poetry` package when using `tox` or PEP517 installer.
2. Fix missing dependencies in `tox.ini` that cause tests to fail.